### PR TITLE
🔧 Laravel 11 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "php": "^8.1",
         "filament/filament": "^3.0-stable",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0"
+        "illuminate/contracts": "^10.0|^11"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
+        "nunomaduro/collision": "^7.8|^8.0",
         "larastan/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.8",
+        "orchestra/testbench": "^8.8|^9.0",
         "pestphp/pest": "^2.20",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",


### PR DESCRIPTION
Updated `illuminate/contracts`, `nunomaduro/collision`, and `orchestra/testbench` to support newer versions.